### PR TITLE
[OPS-6486] Bump base image to work around broken inconv()

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN composer install --quiet --no-dev --prefer-dist && \
     cp -a docker/settings.php docker/services.yml html/sites/default && \
     composer run gulp
 
-FROM unocha/php7-k8s:7.3.14-r0-202003-02-NR
+FROM unocha/php7-k8s:7.3.14-r0-202003-03-NR
 
 ARG VCS_REF
 ARG VCS_URL


### PR DESCRIPTION
Fix the use of the GNU iconv library by php7-iconv in the upstream docker image.