### PR TITLE
Focus search input

### DIFF
--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.theme
@@ -31,6 +31,8 @@ function common_design_subtheme_form_alter(&$form, FormStateInterface $form_stat
     $form['#attributes']['data-cd-icon'][] = '';
     $form['#attributes']['data-cd-component'][] = 'cd-search--inline';
     $form['#attributes']['data-cd-logo'][] = 'search';
+    // Focus the input when clicking on the "toggling" button.
+    $form['#attributes']['data-cd-focus-target'] = 'cd-search--inline';
     $form['s']['#attributes']['placeholder'][] = t('What are you looking for?');
     $form['s']['#attributes']['class'][] = 'cd-search--inline__input';
     $form['s']['#attributes']['type'][] = 'search';


### PR DESCRIPTION
Issue: https://github.com/UN-OCHA/common_design/issues/87

This adds an attribute to use the cd-dropdown.js focus handling when expanding the search on small screens to ensure the input gets the focus.