### PR TITLE
OPS-7333 remove patch and bump base theme version to fix CSS aggregation

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2070,7 +2070,8 @@
                 },
                 "patches_applied": {
                     "https://www.drupal.org/project/external_entities/issues/3202811": "https://www.drupal.org/files/issues/2021-03-10/i3202811-support-geofield.patch",
-                    "https://www.drupal.org/project/external_entities/issues/3202814": "https://www.drupal.org/files/issues/2021-03-10/i3202814-allow-array-of.patch"
+                    "https://www.drupal.org/project/external_entities/issues/3202814": "https://www.drupal.org/files/issues/2021-03-10/i3202814-allow-array-of.patch",
+                    "Dateranges": "./PATCHES/external_entities-daterange.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -7686,16 +7687,16 @@
         },
         {
             "name": "unocha/common_design",
-            "version": "v3.0.0",
+            "version": "v3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/UN-OCHA/common_design.git",
-                "reference": "feef124a654b4e172e87b9bc05764c34b69746f3"
+                "reference": "63f8a577e36adf17984ba268c66307d741104a44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/feef124a654b4e172e87b9bc05764c34b69746f3",
-                "reference": "feef124a654b4e172e87b9bc05764c34b69746f3",
+                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/63f8a577e36adf17984ba268c66307d741104a44",
+                "reference": "63f8a577e36adf17984ba268c66307d741104a44",
                 "shasum": ""
             },
             "require": {
@@ -7707,10 +7708,10 @@
             ],
             "description": "OCHA Common Design base theme for Drupal 8",
             "support": {
-                "source": "https://github.com/UN-OCHA/common_design/tree/v3.0.0",
+                "source": "https://github.com/UN-OCHA/common_design/tree/v3.0.1",
                 "issues": "https://github.com/UN-OCHA/common_design/issues"
             },
-            "time": "2021-03-10T17:06:10+00:00"
+            "time": "2021-03-15T13:05:03+00:00"
         },
         {
             "name": "unocha/ocha_integrations",

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -1,8 +1,5 @@
 {
   "patches": {
-    "drupal/core": {
-      "https://www.drupal.org/project/drupal/issues/2936067": "https://www.drupal.org/files/issues/2021-01-28/2936067-25.patch"
-    },
     "drupal/facets": {
       "https://www.drupal.org/project/facets/issues/3005040": "https://www.drupal.org/files/issues/2018-10-09/facets-hierarchy-allow-different-types-3005040-7.patch"
     },


### PR DESCRIPTION
1. Remove patch to fix semi colon issue in google font url breaking css aggregation
2. bump base theme version with alternative fix

Follow up to #172 and #173