### PR TITLE
[AR-219] Change the way we intercept (and pass) docstore requests.

### DIFF
--- a/docker/etc/nginx/apps/drupal/drupal.conf
+++ b/docker/etc/nginx/apps/drupal/drupal.conf
@@ -32,8 +32,26 @@ location / {
     ## Using a nested location is the 'correct' way to use regexes.
 
     ## Pass requests for attachments to the docstore.
-    location ~ "^/attachments/(?<uuid>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/(?<filename>[^/]+)(?<extension>\.[0-9a-zA-Z]+)$" {
-      proxy_pass http://docstore.ahconu.org.internal/files/$uuid/$filename$extension;
+    # location ~ "^/attachments/(?<uuid>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/(?<filename>[^/]+)(?<extension>\.[0-9a-zA-Z]+)$" {
+    #   proxy_pass http://docstore.ahconu.org.internal/files/$uuid/$filename$extension;
+    # }
+    ## 
+    ## Turns out the above regex fails to match on *some* files that have a space (encoded as %20) in
+    ## their name, in combination with a full stop. This is irritating. Thr result is an *invalid* proxy
+    ## request to the docstore! So, we're going to be really unspecific and make the docstore handle the
+    ## UUID and filename matching slash validation bit.
+    ##
+    ## Also, do not attempt to buffer, just throw the data out right away and close the docstore connection
+    ## when done.
+    location ^~ /attachments/ {
+      # Rewrite the url to what the dcostore wants.
+      rewrite /attachments/(.+)$ /files/$1 break;
+      proxy_pass http://docstore.ahconu.org.internal;
+      # Override connection and buffer vars.
+      proxy_set_header Connection '';
+      proxy_buffering off;
+      tcp_nodelay on;
+      tcp_nopush off;
     }
 
     ## Regular private file serving (i.e. handled by Drupal).


### PR DESCRIPTION
Because, as it turns out, the regex we had did *not* always match URLs
in nginx that it should have matched (and that match fine when testing
the regex). E.g: `01.%20HPC_2021-StepByStep_Guide_0.pdf` tests fine, but
nginx refuses.