### PR TITLE
OPS-7350 Trigger docker builds for all feature/* branches

### DIFF
--- a/.github/workflows/docker-build-image.yml
+++ b/.github/workflows/docker-build-image.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - develop
-      - feature/docstore
       - 'feature/**'
       - main
   release:

--- a/.github/workflows/docker-build-image.yml
+++ b/.github/workflows/docker-build-image.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - feature/docstore
+      - 'feature/**'
       - main
   release:
     types: [published]


### PR DESCRIPTION
@cafuego @attiks Can this be more broad so any feature branches can be deployed to the dev site?
Should the specific `'feature/docstore` be removed?