### PR TITLE
[AR-224] add local groups with hrinfo id

### DIFF
--- a/config/core.entity_form_display.local_group.local_group.default.yml
+++ b/config/core.entity_form_display.local_group.local_group.default.yml
@@ -1,0 +1,33 @@
+
+uuid: 1e48004e-e600-4f62-9e1e-f69960945bfe
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.local_group.local_group.field_hrinfo_id
+  module:
+    - external_entities
+id: local_group.local_group.default
+targetEntityType: local_group
+bundle: local_group
+mode: default
+content:
+  field_hrinfo_id:
+    weight: 1
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    type: number_integer
+    region: content
+  title:
+    type: string
+    label: hidden
+    region: content
+    weight: 0
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+hidden:
+  search_api_excerpt: true

--- a/config/core.entity_view_display.local_group.local_group.default.yml
+++ b/config/core.entity_view_display.local_group.local_group.default.yml
@@ -1,0 +1,32 @@
+uuid: 1e48004e-e600-4f62-9e1e-f69960945bfe
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.local_group.local_group.field_hrinfo_id
+  module:
+    - external_entities
+id: local_group.local_group.default
+targetEntityType: local_group
+bundle: local_group
+mode: default
+content:
+  field_hrinfo_id:
+    weight: 1
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    type: number_integer
+    region: content
+  title:
+    type: string
+    label: hidden
+    region: content
+    weight: 0
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+hidden:
+  search_api_excerpt: true

--- a/config/external_entities.external_entity_type.local_group.yml
+++ b/config/external_entities.external_entity_type.local_group.yml
@@ -14,6 +14,8 @@ field_mappings:
     value: uuid
   title:
     value: label
+  field_hrinfo_id:
+    value: id
 storage_client_id: restjson
 storage_client_config:
   endpoint: 'http://docstore.local.docksal/api/v1/vocabularies/local_coordination_groups/terms'

--- a/config/field.field.local_group.local_group.field_hrinfo_id.yml
+++ b/config/field.field.local_group.local_group.field_hrinfo_id.yml
@@ -1,0 +1,24 @@
+uuid: a15f136a-9b25-4ad1-b457-3f67661b45d0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.local_group.field_hrinfo_id
+  module:
+    - external_entities
+id: local_group.local_group.field_hrinfo_id
+field_name: field_hrinfo_id
+entity_type: local_group
+bundle: local_group
+label: 'HRInfo Id'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/field.storage.local_group.field_hrinfo_id.yml
+++ b/config/field.storage.local_group.field_hrinfo_id.yml
@@ -1,0 +1,20 @@
+uuid: 165c8f40-261c-4de0-b1a9-12fbd468f270
+langcode: en
+status: true
+dependencies:
+  module:
+    - external_entities
+id: local_group.field_hrinfo_id
+field_name: field_hrinfo_id
+entity_type: local_group
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/search_api.index.assessments.yml
+++ b/config/search_api.index.assessments.yml
@@ -11,6 +11,8 @@ dependencies:
     - field.storage.assessment.field_disaster
     - field.storage.assessment.field_organizations
     - field.storage.assessment.field_level_of_representation
+    - field.storage.assessment.field_local_coordination_groups
+    - field.storage.local_group.field_hrinfo_id
     - field.storage.assessment.field_locations
     - field.storage.location.field_geolocation
     - field.storage.assessment.field_operations
@@ -100,6 +102,17 @@ field_settings:
     dependencies:
       config:
         - field.storage.assessment.field_disaster
+  field_hrinfo_id:
+    label: 'Local coordination groups » Local group » HRInfo Id'
+    datasource_id: 'entity:assessment'
+    property_path: 'field_local_coordination_groups:entity:field_hrinfo_id'
+    type: integer
+    dependencies:
+      config:
+        - field.storage.assessment.field_local_coordination_groups
+        - field.storage.local_group.field_hrinfo_id
+      module:
+        - external_entities
   field_level_of_representation:
     label: 'Level of Representation'
     datasource_id: 'entity:assessment'
@@ -108,6 +121,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.assessment.field_level_of_representation
+  field_local_coordination_groups:
+    label: 'Local Coordination Group(s)'
+    datasource_id: 'entity:assessment'
+    property_path: field_local_coordination_groups
+    type: string
+    dependencies:
+      config:
+        - field.storage.assessment.field_local_coordination_groups
   field_locations:
     label: Location(s)
     datasource_id: 'entity:assessment'


### PR DESCRIPTION
Further to https://github.com/UN-OCHA/assessmentregistry8-site/pull/209 , this adds the HRinfo id and exposes the field in the API (I think).

On the docstore, the 'parent' info for local groups is empty (at least in the ones I looked at). I think we need the parent info to give more context to the local group names on the upload form. I'll look at the 'todo's in https://github.com/UN-OCHA/docstore-site/blob/develop/html/modules/custom/docstore/syncs/docstore_local_coordination_groups.php