### PR TITLE
[AR-224] rename local_groups_id field for api

### DIFF
--- a/config/search_api.index.assessments.yml
+++ b/config/search_api.index.assessments.yml
@@ -102,17 +102,6 @@ field_settings:
     dependencies:
       config:
         - field.storage.assessment.field_disaster
-  field_hrinfo_id:
-    label: 'Local coordination groups » Local group » HRInfo Id'
-    datasource_id: 'entity:assessment'
-    property_path: 'field_local_coordination_groups:entity:field_hrinfo_id'
-    type: integer
-    dependencies:
-      config:
-        - field.storage.assessment.field_local_coordination_groups
-        - field.storage.local_group.field_hrinfo_id
-      module:
-        - external_entities
   field_level_of_representation:
     label: 'Level of Representation'
     datasource_id: 'entity:assessment'
@@ -216,6 +205,17 @@ field_settings:
       config:
         - field.storage.assessment.field_locations
         - field.storage.location.field_geolocation
+      module:
+        - external_entities
+  local_group_id:
+    label: 'Local coordination groups » Local group » HRInfo Id'
+    datasource_id: 'entity:assessment'
+    property_path: 'field_local_coordination_groups:entity:field_hrinfo_id'
+    type: integer
+    dependencies:
+      config:
+        - field.storage.assessment.field_local_coordination_groups
+        - field.storage.local_group.field_hrinfo_id
       module:
         - external_entities
   operation_id:


### PR DESCRIPTION
Renames one field to remove ambiguity in the API, and line up with what HRinfo expects.