### PR TITLE
[OPS-7385] Actions branch tweak (#219)

### DIFF
--- a/.github/workflows/docker-build-image.yml
+++ b/.github/workflows/docker-build-image.yml
@@ -17,8 +17,6 @@ jobs:
       uses: actions/checkout@v1
     - name: Determine environment type
       uses: docker://unocha/actions:determine-environment-main
-      with:
-        - branch_production: main
     - name: Build docker image
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
* [OPS-7385] Tell GHA that `main` is in fact the production branch.

* [OPS-7385] xmldom is required to build *production* assets, so is not a devDependency.

* [OPS-7385] Fine, then we bake an updated action with `main` built-in as default.

[OPS-7385]: https://humanitarian.atlassian.net/browse/OPS-7385
[OPS-7385]: https://humanitarian.atlassian.net/browse/OPS-7385
[OPS-7385]: https://humanitarian.atlassian.net/browse/OPS-7385