### PR TITLE
AR-227 Add CD components as global libraries and allow more HTML via WYSIWYG

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3463,6 +3463,9 @@
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
+                },
+                "patches_applied": {
+                    "https://www.drupal.org/project/social_auth_hid/issues/3188805": "https://git.drupalcode.org/project/social_auth_hid/-/merge_requests/2.diff"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",
@@ -7794,16 +7797,16 @@
         },
         {
             "name": "unocha/common_design",
-            "version": "v3.0.3",
+            "version": "v3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/UN-OCHA/common_design.git",
-                "reference": "2229d1e33013e97712aa75871b0123069ea28883"
+                "reference": "35ae19527ebd91adfe94e2b57e3cc7782369f537"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/2229d1e33013e97712aa75871b0123069ea28883",
-                "reference": "2229d1e33013e97712aa75871b0123069ea28883",
+                "url": "https://api.github.com/repos/UN-OCHA/common_design/zipball/35ae19527ebd91adfe94e2b57e3cc7782369f537",
+                "reference": "35ae19527ebd91adfe94e2b57e3cc7782369f537",
                 "shasum": ""
             },
             "require": {
@@ -7815,10 +7818,10 @@
             ],
             "description": "OCHA Common Design base theme for Drupal 8",
             "support": {
-                "source": "https://github.com/UN-OCHA/common_design/tree/v3.0.3",
+                "source": "https://github.com/UN-OCHA/common_design/tree/v3.0.4",
                 "issues": "https://github.com/UN-OCHA/common_design/issues"
             },
-            "time": "2021-03-22T12:52:14+00:00"
+            "time": "2021-03-25T10:50:13+00:00"
         },
         {
             "name": "unocha/ocha_integrations",

--- a/config/filter.format.full_html.yml
+++ b/config/filter.format.full_html.yml
@@ -41,7 +41,7 @@ filters:
     status: true
     weight: -10
     settings:
-      allowed_html: '<a href hreflang> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol type start> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <s> <sup> <sub> <img src alt data-entity-type data-entity-uuid data-align data-caption> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <hr> <p> <h1> <pre><div class>'
+      allowed_html: '<a class id href hreflang> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol type start> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <s> <sup> <sub> <img src alt data-entity-type data-entity-uuid data-align data-caption> <table class> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <hr> <p><pre><div class id><section class id>'
       filter_html_help: true
       filter_html_nofollow: false
   media_embed:

--- a/html/themes/custom/common_design_subtheme/common_design_subtheme.info.yml
+++ b/html/themes/custom/common_design_subtheme/common_design_subtheme.info.yml
@@ -10,6 +10,8 @@ logo: 'img/logos/logo.svg'
 libraries:
 - common_design_subtheme/global-styling
 - common_design/cd-facets
+- common_design/cd-table
+- common_design/cd-toc
 
 # Regions
 regions:


### PR DESCRIPTION
1. cd-table and cd-toc as global libraries
2. expand allowed HTML to facilitate adding a table of content and onpage anchors, and tables styles
3. bump base theme to v3.0.4