### PR TITLE
[AR-236] Fix active filters

### DIFF
--- a/html/modules/custom/ocha_assessments/component/build/ocha-assessments-list.js
+++ b/html/modules/custom/ocha_assessments/component/build/ocha-assessments-list.js
@@ -241,7 +241,7 @@ const createMarker = () => document.createComment('');
  *    * (") then any non-("), or
  *    * (') then any non-(')
  */
-const lastAttributeNameRegex = 
+const lastAttributeNameRegex =
 // eslint-disable-next-line no-control-regex
 /([ \x09\x0a\x0c\x0d])([^\0-\x1F\x7F-\x9F "'>=/]+)([ \x09\x0a\x0c\x0d]*=[ \x09\x0a\x0c\x0d]*(?:[^ \x09\x0a\x0c\x0d"'`<>=]*|"[^"]*|'[^']*))$/;
 
@@ -2343,7 +2343,7 @@ class LitElement extends UpdatingElement {
             // The last item is kept to try to preserve the cascade order with the
             // assumption that it's most important that last added styles override
             // previous styles.
-            const addStyles = (styles, set) => styles.reduceRight((set, s) => 
+            const addStyles = (styles, set) => styles.reduceRight((set, s) =>
             // Note: On IE set.add() does not return the set
             Array.isArray(s) ? addStyles(s, set) : (set.add(s), set), set);
             // Array.from does not work on Set in IE, otherwise return
@@ -3778,7 +3778,7 @@ class OchaAssessmentsBase extends LitElement {
         options: []
       };
 
-      child.options.forEach(function (option) {
+      child.options.forEach(option => {
         if (typeof option.active !== 'undefined' && option.active) {
           dropdown.selected = option.key;
           this.activeFilters.push(option.key);

--- a/html/modules/custom/ocha_assessments/component/build/ocha-assessments-map.js
+++ b/html/modules/custom/ocha_assessments/component/build/ocha-assessments-map.js
@@ -241,7 +241,7 @@ const createMarker = () => document.createComment('');
  *    * (") then any non-("), or
  *    * (') then any non-(')
  */
-const lastAttributeNameRegex = 
+const lastAttributeNameRegex =
 // eslint-disable-next-line no-control-regex
 /([ \x09\x0a\x0c\x0d])([^\0-\x1F\x7F-\x9F "'>=/]+)([ \x09\x0a\x0c\x0d]*=[ \x09\x0a\x0c\x0d]*(?:[^ \x09\x0a\x0c\x0d"'`<>=]*|"[^"]*|'[^']*))$/;
 
@@ -2298,7 +2298,7 @@ class LitElement extends UpdatingElement {
             // The last item is kept to try to preserve the cascade order with the
             // assumption that it's most important that last added styles override
             // previous styles.
-            const addStyles = (styles, set) => styles.reduceRight((set, s) => 
+            const addStyles = (styles, set) => styles.reduceRight((set, s) =>
             // Note: On IE set.add() does not return the set
             Array.isArray(s) ? addStyles(s, set) : (set.add(s), set), set);
             // Array.from does not work on Set in IE, otherwise return
@@ -3691,7 +3691,7 @@ class OchaAssessmentsBase extends LitElement {
         options: []
       };
 
-      child.options.forEach(function (option) {
+      child.options.forEach(option => {
         if (typeof option.active !== 'undefined' && option.active) {
           dropdown.selected = option.key;
           this.activeFilters.push(option.key);

--- a/html/modules/custom/ocha_assessments/component/build/ocha-assessments-table.js
+++ b/html/modules/custom/ocha_assessments/component/build/ocha-assessments-table.js
@@ -241,7 +241,7 @@ const createMarker = () => document.createComment('');
  *    * (") then any non-("), or
  *    * (') then any non-(')
  */
-const lastAttributeNameRegex = 
+const lastAttributeNameRegex =
 // eslint-disable-next-line no-control-regex
 /([ \x09\x0a\x0c\x0d])([^\0-\x1F\x7F-\x9F "'>=/]+)([ \x09\x0a\x0c\x0d]*=[ \x09\x0a\x0c\x0d]*(?:[^ \x09\x0a\x0c\x0d"'`<>=]*|"[^"]*|'[^']*))$/;
 
@@ -2298,7 +2298,7 @@ class LitElement extends UpdatingElement {
             // The last item is kept to try to preserve the cascade order with the
             // assumption that it's most important that last added styles override
             // previous styles.
-            const addStyles = (styles, set) => styles.reduceRight((set, s) => 
+            const addStyles = (styles, set) => styles.reduceRight((set, s) =>
             // Note: On IE set.add() does not return the set
             Array.isArray(s) ? addStyles(s, set) : (set.add(s), set), set);
             // Array.from does not work on Set in IE, otherwise return
@@ -3691,7 +3691,7 @@ class OchaAssessmentsBase extends LitElement {
         options: []
       };
 
-      child.options.forEach(function (option) {
+      child.options.forEach(option => {
         if (typeof option.active !== 'undefined' && option.active) {
           dropdown.selected = option.key;
           this.activeFilters.push(option.key);

--- a/html/modules/custom/ocha_assessments/component/src/ocha-assessments-base.js
+++ b/html/modules/custom/ocha_assessments/component/src/ocha-assessments-base.js
@@ -130,7 +130,7 @@ export class OchaAssessmentsBase extends LitElement {
         options: []
       };
 
-      child.options.forEach(function (option) {
+      child.options.forEach(option => {
         if (typeof option.active !== 'undefined' && option.active) {
           dropdown.selected = option.key;
           this.activeFilters.push(option.key);


### PR DESCRIPTION
Ticket: AR-236

This fixes an issue when selecting a filter in the `/list`, `/table` or `/map`.

<img width="662" alt="Screen Shot 2021-04-14 at 7 44 33" src="https://user-images.githubusercontent.com/696348/114635055-dab73c80-9cfe-11eb-8813-daee36004f14.png">
<img width="1275" alt="Screen Shot 2021-04-14 at 7 44 14" src="https://user-images.githubusercontent.com/696348/114635061-dd199680-9cfe-11eb-87bf-a6138c83fc0d.png">


Note: this was already fixed (another way) in https://github.com/UN-OCHA/assessmentregistry8-site/commit/2e10c28fe2b5defddcbab3a949a020f603d9f285#diff-bdf5be257c607efdfa8e89bd22207f26aa95721b1c7ee043ad18cc10daef3d24 but I just realized that I didn't change the code of the `src` base.js at that time.