### PR TITLE
[AR-249] Load single: use individual resource endpoint

### DIFF
--- a/html/modules/custom/ocha_docstore_files/src/Plugin/ExternalEntities/StorageClient/RestJson.php
+++ b/html/modules/custom/ocha_docstore_files/src/Plugin/ExternalEntities/StorageClient/RestJson.php
@@ -89,7 +89,17 @@ class RestJson extends Rest implements PluginFormInterface {
       }
     }
 
-    if (!empty($ids)) {
+    // Call the individual resource endpoint if there is a single ID to load.
+    if (count($ids) === 1) {
+      return $this->load(reset($ids));
+    }
+    // Otherwise perform batch requests.
+    //
+    // @todo we could perform parallel requests (ex: 5 or so) via a pool
+    // instead of sequential ones to improve performances.
+    //
+    // @see https://docs.guzzlephp.org/en/stable/quickstart.html#concurrent-requests
+    elseif (!empty($ids)) {
       // Limit to 50 to avoid issues with the query URL being too long.
       // We could probaly go up to 100 if we could use a simplified syntax for
       // the uuid filter like a comma separated list of uuids.


### PR DESCRIPTION
Ticket: AR-249

This add a check to call the individual resource endpoint when there is only 1 entity to load to avoid unnecessary SolR requests. This needs https://github.com/UN-OCHA/docstore-site/pull/161 to make sense.