### PR TITLE
[OPS-7692] The warning suppression line now generates a warning.

### DIFF
--- a/docker/etc/nginx/nginx.conf
+++ b/docker/etc/nginx/nginx.conf
@@ -34,9 +34,6 @@ events {
 
 
 http {
-  ## Suppress a LUA error at startup.
-  lua_load_resty_core off;
-
   include /etc/nginx/mime.types;
   default_type application/octet-stream;
 


### PR DESCRIPTION
 This whole config can go once we bump images again. See https://github.com/UN-OCHA/docker-images/pull/277