### PR TITLE
[AR-283] hide related content field

### DIFF
--- a/config/core.entity_form_display.assessment.assessment.default.yml
+++ b/config/core.entity_form_display.assessment.assessment.default.yml
@@ -32,7 +32,6 @@ dependencies:
   module:
     - external_entities
     - inline_entity_form
-    - link
     - ocha_docstore_files
     - path
     - select2
@@ -43,7 +42,7 @@ mode: default
 content:
   field_assessment_data:
     type: inline_entity_form_complex
-    weight: 25
+    weight: 23
     region: content
     settings:
       form_mode: default
@@ -60,7 +59,7 @@ content:
     third_party_settings: {  }
   field_assessment_questionnaire:
     type: inline_entity_form_complex
-    weight: 26
+    weight: 24
     region: content
     settings:
       form_mode: default
@@ -77,7 +76,7 @@ content:
     third_party_settings: {  }
   field_assessment_report:
     type: inline_entity_form_complex
-    weight: 24
+    weight: 22
     region: content
     settings:
       form_mode: default
@@ -133,7 +132,7 @@ content:
     third_party_settings: {  }
   field_disaster:
     type: select2_entity_reference
-    weight: 20
+    weight: 18
     region: content
     settings:
       width: 100%
@@ -165,7 +164,7 @@ content:
     third_party_settings: {  }
   field_local_coordination_groups:
     type: select2_entity_reference
-    weight: 23
+    weight: 21
     region: content
     settings:
       width: 100%
@@ -175,7 +174,7 @@ content:
     third_party_settings: {  }
   field_locations:
     type: select2_entity_reference
-    weight: 18
+    weight: 16
     region: content
     settings:
       width: 100%
@@ -193,7 +192,7 @@ content:
     third_party_settings: {  }
   field_operations:
     type: select2_entity_reference
-    weight: 21
+    weight: 19
     region: content
     settings:
       width: 100%
@@ -213,7 +212,7 @@ content:
     third_party_settings: {  }
   field_other_location:
     type: string_textfield
-    weight: 19
+    weight: 17
     region: content
     settings:
       size: 60
@@ -231,22 +230,14 @@ content:
     third_party_settings: {  }
   field_published:
     type: boolean_checkbox
-    weight: 27
+    weight: 25
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
-  field_related_content:
-    type: link_default
-    weight: 12
-    region: content
-    settings:
-      placeholder_url: ''
-      placeholder_title: ''
-    third_party_settings: {  }
   field_sample_size:
     type: string_textfield
-    weight: 13
+    weight: 12
     region: content
     settings:
       size: 60
@@ -254,7 +245,7 @@ content:
     third_party_settings: {  }
   field_status:
     type: select2_entity_reference
-    weight: 17
+    weight: 15
     region: content
     settings:
       width: 100%
@@ -264,7 +255,7 @@ content:
     third_party_settings: {  }
   field_subject_objective:
     type: string_textarea
-    weight: 15
+    weight: 13
     region: content
     settings:
       rows: 5
@@ -272,7 +263,7 @@ content:
     third_party_settings: {  }
   field_themes:
     type: select2_entity_reference
-    weight: 16
+    weight: 14
     region: content
     settings:
       width: 100%
@@ -282,7 +273,7 @@ content:
     third_party_settings: {  }
   field_units_of_measurement:
     type: select2_entity_reference
-    weight: 22
+    weight: 20
     region: content
     settings:
       width: 100%
@@ -292,7 +283,7 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 28
+    weight: 26
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -304,4 +295,5 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  field_related_content: true


### PR DESCRIPTION
[AR-283]

updates config to match what's now on prod. https://assessments.hpc.tools/admin/config/development/configuration

We probably need another ticket to remove the field, or to add mapping for it to the docstore, but this is just to ensure the next deployment doesn't un-hide the field.

[AR-283]: https://humanitarian.atlassian.net/browse/AR-283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ