### PR TITLE
[OPS-7459} add and configure user_expire without other changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
         "drupal/seckit": "^2.0",
         "drupal/select2": "^1.13",
         "drupal/social_auth_hid": "^3.1.0",
+        "drupal/user_expire": "^1.0",
         "drupal/views_data_export": "^1.0",
         "drush/drush": "^10.4",
         "npm-asset/select2": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "04dc2543b3e748a489c4c61bd00a31ca",
+    "content-hash": "417dd649d6499a5bf1d167be8b44c109",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -4647,6 +4647,61 @@
             "homepage": "https://www.drupal.org/project/token",
             "support": {
                 "source": "https://git.drupalcode.org/project/token"
+            }
+        },
+        {
+            "name": "drupal/user_expire",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/user_expire.git",
+                "reference": "8.x-1.0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/user_expire-8.x-1.0.zip",
+                "reference": "8.x-1.0",
+                "shasum": "70c5ebffe7f28f97c270de0c004dbfd4c174ffb8"
+            },
+            "require": {
+                "drupal/core": "^8.8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-1.0",
+                    "datestamp": "1633965091",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Erik Webb (erikwebb)",
+                    "homepage": "https://www.drupal.org/u/erikwebb",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Greg Knaddison (greggles)",
+                    "homepage": "https://www.drupal.org/u/greggles",
+                    "role": "Co-maintainer"
+                },
+                {
+                    "name": "shelane",
+                    "homepage": "https://www.drupal.org/user/2674989"
+                }
+            ],
+            "description": "Allows an administrator to define a date on which to expire a user account.",
+            "homepage": "https://www.drupal.org/project/user_expire",
+            "support": {
+                "source": "https://git.drupal.org/project/user_expire.git",
+                "issues": "https://www.drupal.org/project/issues/user_expire"
             }
         },
         {

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -16,6 +16,10 @@
     "drupal/redis": {
       "https://www.drupal.org/project/redis/issues/3192255": "https://git.drupalcode.org/project/redis/-/merge_requests/3.diff"
     },
+    "drupal/user_expire": {
+      "Allow the notification email to be customised": "https://git.drupalcode.org/project/user_expire/-/merge_requests/5.diff",
+      "Reset expiration when user is reactivated": "https://git.drupalcode.org/project/user_expire/-/merge_requests/6.diff"
+    },
     "drupal/views_data_export": {
       "Ensure the proper number of items is processed in batch export": "PATCHES/views_data_export-fix-number-of-processed-items.patch"
     }

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -87,6 +87,7 @@ module:
   toolbar: 0
   update: 0
   user: 0
+  user_expire: 0
   views_data_export: 0
   menu_link_content: 1
   pathauto: 1

--- a/config/user_expire.settings.yml
+++ b/config/user_expire.settings.yml
@@ -1,0 +1,8 @@
+frequency: 432000
+mail:
+  subject: ''
+  body: ''
+offset: 604800
+send_mail: 1
+user_expire_roles:
+  authenticated: 15552000


### PR DESCRIPTION
[OPS-7459]

As https://github.com/UN-OCHA/assessmentregistry8-site/pull/360 got complicated by changes to external_entities module, this is the same but only adding and configuring the user_expire module.

[OPS-7459]: https://humanitarian.atlassian.net/browse/OPS-7459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ