### PR TITLE
[OPS-7998] update facets module to 2.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "drupal/dream_block_manager": "^1.0",
         "drupal/external_entities": "^2.0-alpha3",
         "drupal/external_media": "^1.0",
-        "drupal/facets": "^1.8",
+        "drupal/facets": "^2.0.2",
         "drupal/facets_pretty_paths": "^1.1",
         "drupal/field_group": "^3.2",
         "drupal/google_tag": "^1.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "04dc2543b3e748a489c4c61bd00a31ca",
+    "content-hash": "5a4cd4087474c2dd96329fcb76f93ce5",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3223,39 +3223,42 @@
         },
         {
             "name": "drupal/facets",
-            "version": "1.8.0",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/facets.git",
-                "reference": "8.x-1.8"
+                "reference": "2.0.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/facets-8.x-1.8.zip",
-                "reference": "8.x-1.8",
-                "shasum": "f621b84b59c5315db14a0529df5dfc74ca5bc9de"
+                "url": "https://ftp.drupal.org/files/projects/facets-2.0.2.zip",
+                "reference": "2.0.2",
+                "shasum": "17afc46d3f4e4300e8e69f23b3b01a4935b57104"
             },
             "require": {
-                "drupal/core": "^8.8 || ^9"
+                "drupal/core": "^9.2 || ^10.0"
             },
             "conflict": {
                 "drupal/search_api": "<1.14"
             },
             "require-dev": {
-                "drupal/search_api": "~1.14"
+                "drupal/jquery_ui_slider": "~1.1",
+                "drupal/jquery_ui_touch_punch": "~1.0",
+                "drupal/search_api": "~1.21"
+            },
+            "suggest": {
+                "drupal/jquery_ui_slider": "Required for the 'Facets Range Widget' module to work",
+                "drupal/jquery_ui_touch_punch": "Required for the 'Facets Range Widget' module to work"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-1.8",
-                    "datestamp": "1620838256",
+                    "version": "2.0.2",
+                    "datestamp": "1649070269",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
                     }
-                },
-                "branch-alias": {
-                    "dev-8.x-1.x": "1.x-dev"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -3,9 +3,6 @@
     "drupal/core": {
       "https://www.drupal.org/project/drupal/issues/2859042#comment-12366507": "https://www.drupal.org/files/issues/entity-original_revision-2926483-17.patch"
     },
-    "drupal/facets": {
-      "https://www.drupal.org/project/facets/issues/3005040": "https://www.drupal.org/files/issues/2021-05-13/facets-hierarchy-allow-different-types-3005040-13.patch"
-    },
     "drupal/external_entities": {
       "Dateranges - https://www.drupal.org/project/external_entities/issues/3230639": "https://www.drupal.org/files/issues/2021-08-31/external_entities-daterange.patch",
       "Always pass boolean fields - https://www.drupal.org/project/external_entities/issues/3230638#comment-14205286": "https://www.drupal.org/files/issues/2021-08-31/external_entity_boolean_0.patch"


### PR DESCRIPTION
[OPS-7998]

When I tried this update to facets before I had an issue with drush not working, but all seems good now. The patch has now been merged: https://www.drupal.org/project/facets/issues/3005040#comment-14361940

[OPS-7998]: https://humanitarian.atlassian.net/browse/OPS-7998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ