### PR TITLE
fix: revert external_entities while still in alpha

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "drupal/ctools": "^3.7",
         "drupal/custom_widgets": "^2.0",
         "drupal/dream_block_manager": "^1.0",
-        "drupal/external_entities": "^2.0-alpha3",
+        "drupal/external_entities": "2.0-alpha3",
         "drupal/external_media": "^1.0",
         "drupal/facets": "^2.0.2",
         "drupal/facets_pretty_paths": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "72b0cfc82ecbc59eb8d975787afe9b81",
+    "content-hash": "c6cf711918893f6ecc14f88f2a2c6131",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3145,27 +3145,26 @@
         },
         {
             "name": "drupal/external_entities",
-            "version": "2.0.0-alpha5",
+            "version": "2.0.0-alpha3",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/external_entities.git",
-                "reference": "8.x-2.0-alpha5"
+                "reference": "8.x-2.0-alpha3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/external_entities-8.x-2.0-alpha5.zip",
-                "reference": "8.x-2.0-alpha5",
-                "shasum": "ce2402ec96805598f3664e8a61ad68b30190b92b"
+                "url": "https://ftp.drupal.org/files/projects/external_entities-8.x-2.0-alpha3.zip",
+                "reference": "8.x-2.0-alpha3",
+                "shasum": "efa25c55ea4871b72160fb93c6f709d389396b11"
             },
             "require": {
-                "drupal/core": "^8.8 || ^9",
-                "galbar/jsonpath": "^2.0"
+                "drupal/core": "^8.8 || ^9"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-2.0-alpha5",
-                    "datestamp": "1648796532",
+                    "version": "8.x-2.0-alpha3",
+                    "datestamp": "1632314741",
                     "security-coverage": {
                         "status": "not-covered",
                         "message": "Alpha releases are not covered by Drupal security advisories."
@@ -3217,8 +3216,7 @@
             "description": "Allows using remote entities, for example through a REST interface.",
             "homepage": "https://www.drupal.org/project/external_entities",
             "support": {
-                "source": "http://cgit.drupalcode.org/external_entities",
-                "issues": "http://drupal.org/project/issues/external_entities"
+                "source": "https://git.drupalcode.org/project/external_entities"
             }
         },
         {
@@ -5218,58 +5216,6 @@
                 "source": "https://github.com/FriendsOfBehat/MinkBrowserKitDriver/tree/v1.6.1"
             },
             "time": "2021-12-13T10:41:57+00:00"
-        },
-        {
-            "name": "galbar/jsonpath",
-            "version": "2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Galbar/JsonPath-PHP.git",
-                "reference": "eab3a7e97d1bcf23b77df87c5ada241789b17c79"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Galbar/JsonPath-PHP/zipball/eab3a7e97d1bcf23b77df87c5ada241789b17c79",
-                "reference": "eab3a7e97d1bcf23b77df87c5ada241789b17c79",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0",
-                "sami/sami": ">=3.3.0",
-                "satooshi/php-coveralls": ">=1.0.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "JsonPath\\": "src/Galbar/JsonPath",
-                    "Utilities\\": "src/Galbar/Utilities"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "authors": [
-                {
-                    "name": "Alessio Linares",
-                    "email": "alessio@alessio.cc",
-                    "role": "Software Engineer"
-                }
-            ],
-            "description": "JSONPath implementation for querying and updating JSON objects",
-            "keywords": [
-                "json",
-                "jsonpath",
-                "path"
-            ],
-            "support": {
-                "issues": "https://github.com/Galbar/JsonPath-PHP/issues",
-                "source": "https://github.com/Galbar/JsonPath-PHP/tree/2.0"
-            },
-            "time": "2021-08-19T20:32:43+00:00"
         },
         {
             "name": "grasmash/expander",

--- a/html/.htaccess
+++ b/html/.htaccess
@@ -32,6 +32,11 @@ AddEncoding gzip svgz
   php_value assert.active                   0
 </IfModule>
 
+# PHP 8, Apache 1 and 2.
+<IfModule mod_php.c>
+  php_value assert.active                   0
+</IfModule>
+
 # Requires mod_expires to be enabled.
 <IfModule mod_expires.c>
   # Enable expirations.


### PR DESCRIPTION
Refs: OPS-8392

There's a big change in external_entities - https://www.drupal.org/node/3079012 - which means our use of getFieldMappings() no longer works.

This needs some more work before we can update the module, but it's still in alpha, so there's an argument for waiting a bit longer. That work can be tracked on OPS-8392.

This pins the version of external_entities for the moment.