### PR TITLE
fix: update config for new mapping schema

### DIFF
--- a/config/external_entities.external_entity_type.assessment.yml
+++ b/config/external_entities.external_entity_type.assessment.yml
@@ -7,64 +7,66 @@ label: Assessment
 label_plural: assessments
 description: ''
 read_only: false
-field_mappings:
-  id:
-    value: uuid
-  uuid:
-    value: uuid
-  title:
-    value: title
-  field_assessment_data:
-    target_id: assessment_data/0/uuid
-  field_assessment_questionnaire:
-    target_id: assessment_questionnaire/0/uuid
-  field_assessment_report:
-    target_id: assessment_report/0/uuid
-  field_asst_organizations:
-    target_id: 'asst_organizations/*/uuid'
-  field_author:
-    value: author
-  field_collection_methods:
-    value: 'collection_method/*'
-  field_contacts:
-    value: contacts
-  field_date:
-    value: ar_date/start
-    end_value: ar_date/end
-  field_disaster:
-    target_id: 'disasters/*/uuid'
-  field_frequency:
-    value: frequency
-  field_key_findings:
-    value: key_findings
-  field_level_of_representation:
-    value: level_of_representation
-  field_local_coordination_groups:
-    target_id: 'local_groups/*/uuid'
-  field_locations:
-    target_id: 'locations/*/uuid'
-  field_methodology:
-    value: methodology
-  field_operations:
-    target_id: 'operations/*/uuid'
-  field_organizations:
-    target_id: 'organizations/*/uuid'
-  field_other_location:
-    value: other_location
-  field_population_types:
-    target_id: 'population_types/*/uuid'
-  field_published:
-    value: published
-  field_sample_size:
-    value: sample_size
-  field_status:
-    target_id: ar_status/uuid
-  field_subject_objective:
-    value: subject
-  field_themes:
-    target_id: 'themes/*/uuid'
-  field_units_of_measurement:
-    target_id: 'units_of_measurement/*/uuid'
+field_mapper_id: simple
+field_mapper_config:
+  field_mappings:
+    id:
+      value: uuid
+    uuid:
+      value: uuid
+    title:
+      value: title
+    field_assessment_data:
+      target_id: assessment_data/0/uuid
+    field_assessment_questionnaire:
+      target_id: assessment_questionnaire/0/uuid
+    field_assessment_report:
+      target_id: assessment_report/0/uuid
+    field_asst_organizations:
+      target_id: 'asst_organizations/*/uuid'
+    field_author:
+      value: author
+    field_collection_methods:
+      value: 'collection_method/*'
+    field_contacts:
+      value: contacts
+    field_date:
+      value: ar_date/start
+      end_value: ar_date/end
+    field_disaster:
+      target_id: 'disasters/*/uuid'
+    field_frequency:
+      value: frequency
+    field_key_findings:
+      value: key_findings
+    field_level_of_representation:
+      value: level_of_representation
+    field_local_coordination_groups:
+      target_id: 'local_groups/*/uuid'
+    field_locations:
+      target_id: 'locations/*/uuid'
+    field_methodology:
+      value: methodology
+    field_operations:
+      target_id: 'operations/*/uuid'
+    field_organizations:
+      target_id: 'organizations/*/uuid'
+    field_other_location:
+      value: other_location
+    field_population_types:
+      target_id: 'population_types/*/uuid'
+    field_published:
+      value: published
+    field_sample_size:
+      value: sample_size
+    field_status:
+      target_id: ar_status/uuid
+    field_subject_objective:
+      value: subject
+    field_themes:
+      target_id: 'themes/*/uuid'
+    field_units_of_measurement:
+      target_id: 'units_of_measurement/*/uuid'
 storage_client_id: restjson
 storage_client_config:
   endpoint: 'http://docstore.local.docksal/api/v1/documents/assessments'

--- a/config/external_entities.external_entity_type.assessment_document.yml
+++ b/config/external_entities.external_entity_type.assessment_document.yml
@@ -7,24 +7,26 @@ label: 'Assessment document'
 label_plural: 'Assessment documents'
 description: ''
 read_only: false
-field_mappings:
-  id:
-    value: uuid
-  uuid:
-    value: uuid
-  title:
-    value: title
-  field_accessibility:
-    value: accessibility
-  field_author:
-    value: author
-  field_files:
-    media_uuid: 'files/*/uuid'
-    filename: 'files/*/filename'
-    uri: 'files/*/uri'
-    private: 'files/*/private'
-  field_instructions:
-    value: instructions
+field_mapper_id: simple
+field_mapper_config:
+  field_mappings:
+    id:
+      value: uuid
+    uuid:
+      value: uuid
+    title:
+      value: title
+    field_accessibility:
+      value: accessibility
+    field_author:
+      value: author
+    field_files:
+      media_uuid: 'files/*/uuid'
+      filename: 'files/*/filename'
+      uri: 'files/*/uri'
+      private: 'files/*/private'
+    field_instructions:
+      value: instructions
 storage_client_id: restjson
 storage_client_config:
   endpoint: 'http://docstore.local.docksal/api/v1/documents/assessment-documents'

--- a/config/external_entities.external_entity_type.assessment_status.yml
+++ b/config/external_entities.external_entity_type.assessment_status.yml
@@ -7,13 +7,15 @@ label: 'Assessment status'
 label_plural: 'Assessment status'
 description: ''
 read_only: true
-field_mappings:
-  id:
-    value: uuid
-  uuid:
-    value: uuid
-  title:
-    value: label
+field_mapper_id: simple
+field_mapper_config:
+  field_mappings:
+    id:
+      value: uuid
+    uuid:
+      value: uuid
+    title:
+      value: label
 storage_client_id: restjson
 storage_client_config:
   endpoint: 'http://docstore.local.docksal/api/v1/vocabularies/ar_assessment_status/terms'

--- a/config/external_entities.external_entity_type.context.yml
+++ b/config/external_entities.external_entity_type.context.yml
@@ -7,13 +7,15 @@ label: Context
 label_plural: Contexts
 description: ''
 read_only: true
-field_mappings:
-  id:
-    value: uuid
-  uuid:
-    value: uuid
-  title:
-    value: label
+field_mapper_id: simple
+field_mapper_config:
+  field_mappings:
+    id:
+      value: uuid
+    uuid:
+      value: uuid
+    title:
+      value: label
 storage_client_id: restjson
 storage_client_config:
   endpoint: 'http://docstore.local.docksal/api/v1/vocabularies/ar_context/terms'

--- a/config/external_entities.external_entity_type.country.yml
+++ b/config/external_entities.external_entity_type.country.yml
@@ -7,13 +7,15 @@ label: Country
 label_plural: Countries
 description: ''
 read_only: true
-field_mappings:
-  id:
-    value: uuid
-  uuid:
-    value: uuid
-  title:
-    value: label
+field_mapper_id: simple
+field_mapper_config:
+  field_mappings:
+    id:
+      value: uuid
+    uuid:
+      value: uuid
+    title:
+      value: label
 storage_client_id: restjson
 storage_client_config:
   endpoint: 'http://docstore.local.docksal/api/v1/vocabularies/countries/terms'

--- a/config/external_entities.external_entity_type.disaster.yml
+++ b/config/external_entities.external_entity_type.disaster.yml
@@ -7,13 +7,15 @@ label: Disaster
 label_plural: Disasters
 description: ''
 read_only: true
-field_mappings:
-  id:
-    value: uuid
-  uuid:
-    value: uuid
-  title:
-    value: title
+field_mapper_id: simple
+field_mapper_config:
+  field_mappings:
+    id:
+      value: uuid
+    uuid:
+      value: uuid
+    title:
+      value: title
 storage_client_id: restjson
 storage_client_config:
   endpoint: 'http://docstore.local.docksal/api/v1/documents/disasters'

--- a/config/external_entities.external_entity_type.document_type.yml
+++ b/config/external_entities.external_entity_type.document_type.yml
@@ -7,13 +7,15 @@ label: 'Document type'
 label_plural: 'Document types'
 description: ''
 read_only: true
-field_mappings:
-  id:
-    value: uuid
-  uuid:
-    value: uuid
-  title:
-    value: label
+field_mapper_id: simple
+field_mapper_config:
+  field_mappings:
+    id:
+      value: uuid
+    uuid:
+      value: uuid
+    title:
+      value: label
 storage_client_id: restjson
 storage_client_config:
   endpoint: 'http://docstore.local.docksal/api/v1/vocabularies/ar_document_type/terms'

--- a/config/external_entities.external_entity_type.global_cluster.yml
+++ b/config/external_entities.external_entity_type.global_cluster.yml
@@ -7,13 +7,15 @@ label: 'Global cluster'
 label_plural: 'Global clusters'
 description: ''
 read_only: true
-field_mappings:
-  id:
-    value: uuid
-  uuid:
-    value: uuid
-  title:
-    value: label
+field_mapper_id: simple
+field_mapper_config:
+  field_mappings:
+    id:
+      value: uuid
+    uuid:
+      value: uuid
+    title:
+      value: label
 storage_client_id: restjson
 storage_client_config:
   endpoint: 'http://docstore.local.docksal/api/v1/vocabularies/global_coordination_groups/terms'

--- a/config/external_entities.external_entity_type.hpc_document_repository.yml
+++ b/config/external_entities.external_entity_type.hpc_document_repository.yml
@@ -7,13 +7,15 @@ label: 'HPC document repository'
 label_plural: 'HPC document repositories'
 description: ''
 read_only: true
-field_mappings:
-  id:
-    value: uuid
-  uuid:
-    value: uuid
-  title:
-    value: display_name
+field_mapper_id: simple
+field_mapper_config:
+  field_mappings:
+    id:
+      value: uuid
+    uuid:
+      value: uuid
+    title:
+      value: display_name
 storage_client_id: restjson
 storage_client_config:
   endpoint: 'http://docstore.local.docksal/api/v1/vocabularies/ar_hpc_document_repository/terms'

--- a/config/external_entities.external_entity_type.km.yml
+++ b/config/external_entities.external_entity_type.km.yml
@@ -7,40 +7,42 @@ label: km
 label_plural: kms
 description: ''
 read_only: false
-field_mappings:
-  id:
-    value: uuid
-  uuid:
-    value: uuid
-  title:
-    value: title
-  field_author:
-    value: author
-  field_context:
-    target_id: 'ar_context/*/uuid'
-  field_countries:
-    target_id: 'countries/*/uuid'
-  field_description:
-    value: description
-  field_document_type:
-    target_id: 'ar_document_type/*/uuid'
-  field_files:
-    media_uuid: 'files/*/media_uuid'
-    filename: 'files/*/filename'
-    uri: 'files/*/uri'
-    private: 'files/*/private'
-  field_global_clusters:
-    target_id: 'global_cluster/*/uuid'
-  field_hpc_document_repository:
-    target_id: 'ar_hpc_document_repository/*/uuid'
-  field_life_cycle_steps:
-    target_id: 'ar_life_cycle_steps/*/uuid'
-  field_original_publication_date:
-    value: original_publication_date
-  field_population_types:
-    target_id: 'population_types/*/uuid'
-  field_published:
-    value: published
+field_mapper_id: simple
+field_mapper_config:
+  field_mappings:
+    id:
+      value: uuid
+    uuid:
+      value: uuid
+    title:
+      value: title
+    field_author:
+      value: author
+    field_context:
+      target_id: 'ar_context/*/uuid'
+    field_countries:
+      target_id: 'countries/*/uuid'
+    field_description:
+      value: description
+    field_document_type:
+      target_id: 'ar_document_type/*/uuid'
+    field_files:
+      media_uuid: 'files/*/media_uuid'
+      filename: 'files/*/filename'
+      uri: 'files/*/uri'
+      private: 'files/*/private'
+    field_global_clusters:
+      target_id: 'global_cluster/*/uuid'
+    field_hpc_document_repository:
+      target_id: 'ar_hpc_document_repository/*/uuid'
+    field_life_cycle_steps:
+      target_id: 'ar_life_cycle_steps/*/uuid'
+    field_original_publication_date:
+      value: original_publication_date
+    field_population_types:
+      target_id: 'population_types/*/uuid'
+    field_published:
+      value: published
 storage_client_id: restjson
 storage_client_config:
   endpoint: 'http://docstore.local.docksal/api/v1/documents/knowledge-managements'

--- a/config/external_entities.external_entity_type.life_cycle_step.yml
+++ b/config/external_entities.external_entity_type.life_cycle_step.yml
@@ -7,13 +7,15 @@ label: 'Life cycle step'
 label_plural: 'Life cycle steps'
 description: ''
 read_only: false
-field_mappings:
-  id:
-    value: uuid
-  uuid:
-    value: uuid
-  title:
-    value: display_name
+field_mapper_id: simple
+field_mapper_config:
+  field_mappings:
+    id:
+      value: uuid
+    uuid:
+      value: uuid
+    title:
+      value: display_name
 storage_client_id: restjson
 storage_client_config:
   endpoint: 'http://docstore.local.docksal/api/v1/vocabularies/ar_life_cycle_steps/terms'

--- a/config/external_entities.external_entity_type.local_group.yml
+++ b/config/external_entities.external_entity_type.local_group.yml
@@ -7,17 +7,19 @@ label: Cluster
 label_plural: Clusters
 description: ''
 read_only: false
-field_mappings:
-  id:
-    value: uuid
-  uuid:
-    value: uuid
-  title:
-    value: display_name
-  field_hrinfo_id:
-    value: id
-  field_operations:
-    target_id: 'operations/*/uuid'
+field_mapper_id: simple
+field_mapper_config:
+  field_mappings:
+    id:
+      value: uuid
+    uuid:
+      value: uuid
+    title:
+      value: display_name
+    field_hrinfo_id:
+      value: id
+    field_operations:
+      target_id: 'operations/*/uuid'
 storage_client_id: restjson
 storage_client_config:
   endpoint: 'http://docstore.local.docksal/api/v1/vocabularies/local_coordination_groups/terms'

--- a/config/external_entities.external_entity_type.location.yml
+++ b/config/external_entities.external_entity_type.location.yml
@@ -7,21 +7,23 @@ label: Location
 label_plural: Locations
 description: ''
 read_only: true
-field_mappings:
-  id:
-    value: uuid
-  uuid:
-    value: uuid
-  title:
-    value: display_name
-  field_admin_level:
-    value: admin_level
-  field_geolocation:
-    geo_type: +Point
-    lat: geolocation/lat
-    lon: geolocation/lon
-  field_parent:
-    target_id: 'parent/*/uuid'
+field_mapper_id: simple
+field_mapper_config:
+  field_mappings:
+    id:
+      value: uuid
+    uuid:
+      value: uuid
+    title:
+      value: display_name
+    field_admin_level:
+      value: admin_level
+    field_geolocation:
+      geo_type: +Point
+      lat: geolocation/lat
+      lon: geolocation/lon
+    field_parent:
+      target_id: 'parent/*/uuid'
 storage_client_id: restjson
 storage_client_config:
   endpoint: 'http://docstore.local.docksal/api/v1/vocabularies/locations/terms'

--- a/config/external_entities.external_entity_type.operation.yml
+++ b/config/external_entities.external_entity_type.operation.yml
@@ -7,15 +7,17 @@ label: Operation
 label_plural: Operations
 description: ''
 read_only: true
-field_mappings:
-  id:
-    value: uuid
-  uuid:
-    value: uuid
-  title:
-    value: label
-  field_hrinfo_id:
-    value: id
+field_mapper_id: simple
+field_mapper_config:
+  field_mappings:
+    id:
+      value: uuid
+    uuid:
+      value: uuid
+    title:
+      value: label
+    field_hrinfo_id:
+      value: id
 storage_client_id: restjson
 storage_client_config:
   endpoint: 'http://docstore.local.docksal/api/v1/vocabularies/operations/terms'

--- a/config/external_entities.external_entity_type.organization.yml
+++ b/config/external_entities.external_entity_type.organization.yml
@@ -7,13 +7,15 @@ label: Organization
 label_plural: Organizations
 description: ''
 read_only: true
-field_mappings:
-  id:
-    value: uuid
-  uuid:
-    value: uuid
-  title:
-    value: label
+field_mapper_id: simple
+field_mapper_config:
+  field_mappings:
+    id:
+      value: uuid
+    uuid:
+      value: uuid
+    title:
+      value: label
 storage_client_id: restjson
 storage_client_config:
   endpoint: 'http://docstore.local.docksal/api/v1/vocabularies/organizations/terms'

--- a/config/external_entities.external_entity_type.population_type.yml
+++ b/config/external_entities.external_entity_type.population_type.yml
@@ -7,13 +7,15 @@ label: 'Population Type'
 label_plural: 'Population Types'
 description: ''
 read_only: true
-field_mappings:
-  id:
-    value: uuid
-  uuid:
-    value: uuid
-  title:
-    value: label
+field_mapper_id: simple
+field_mapper_config:
+  field_mappings:
+    id:
+      value: uuid
+    uuid:
+      value: uuid
+    title:
+      value: label
 storage_client_id: restjson
 storage_client_config:
   endpoint: 'http://docstore.local.docksal/api/v1/vocabularies/population_types/terms'

--- a/config/external_entities.external_entity_type.theme.yml
+++ b/config/external_entities.external_entity_type.theme.yml
@@ -7,13 +7,15 @@ label: Theme
 label_plural: Themes
 description: ''
 read_only: true
-field_mappings:
-  id:
-    value: uuid
-  uuid:
-    value: uuid
-  title:
-    value: label
+field_mapper_id: simple
+field_mapper_config:
+  field_mappings:
+    id:
+      value: uuid
+    uuid:
+      value: uuid
+    title:
+      value: label
 storage_client_id: restjson
 storage_client_config:
   endpoint: 'http://docstore.local.docksal/api/v1/vocabularies/themes/terms'

--- a/config/external_entities.external_entity_type.unit_of_measurement.yml
+++ b/config/external_entities.external_entity_type.unit_of_measurement.yml
@@ -7,13 +7,15 @@ label: 'Unit of measurement'
 label_plural: 'Units of measurement'
 description: ''
 read_only: true
-field_mappings:
-  id:
-    value: uuid
-  uuid:
-    value: uuid
-  title:
-    value: label
+field_mapper_id: simple
+field_mapper_config:
+  field_mappings:
+    id:
+      value: uuid
+    uuid:
+      value: uuid
+    title:
+      value: label
 storage_client_id: restjson
 storage_client_config:
   endpoint: 'http://docstore.local.docksal/api/v1/vocabularies/ar_units_of_measurement/terms'


### PR DESCRIPTION
Refs: AR-286

Was getting an error:
```
  | Drupal\Component\Plugin\Exception\PluginNotFoundException: The "" plugin does not exist. Valid plugin IDs for Drupal\external_entities\FieldMapper\FieldMapperManager are: jsonpath, simple in Drupal\Core\Plugin\DefaultPluginManager->doGetDefinition() (line 53 of /srv/www/html/core/lib/Drupal/Component/Plugin/Discovery/DiscoveryTrait.php).
-- | --
```
and discovered the config needed updating.