### PR TITLE
fix: update template to match variable name change in external_entities

### DIFF
--- a/html/themes/custom/common_design_subtheme/templates/content/external-entity--assessment--full.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/external-entity--assessment--full.html.twig
@@ -4,7 +4,7 @@
  * Default theme implementation to display an external entity.
  *
  * Available variables:
- * - entity: The external entity.
+ * - content: The external entity.
 */
 #}
 {%
@@ -20,9 +20,9 @@
 
 <article{{ attributes.addClass(classes) }}>
   {% if logged_in %}
-    {{ entity }}
+    {{ content }}
   {% else %}
     {# See field--assessment--field-contacts.html.twig #}
-    {{ entity|without('field_contacts') }}
+    {{ content|without('field_contacts') }}
   {% endif %}
 </article>

--- a/html/themes/custom/common_design_subtheme/templates/content/external-entity--assessment--teaser.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/external-entity--assessment--teaser.html.twig
@@ -4,7 +4,7 @@
  * Default theme implementation to display an external entity.
  *
  * Available variables:
- * - entity: The external entity.
+ * - content: The external entity.
 */
 #}
 {%
@@ -19,15 +19,15 @@
 
   <div class="cd-teaser__container [ cd-flow ]">
     <h3 class="cd-teaser__title">
-      {{ entity.title }}
+      {{ content.title }}
     </h3>
 
     <div class="cd-teaser__description node__content">
 
-      {{ entity.field_organizations }}
-      {{ entity.field_asst_organizations }}
-      {{ entity.field_status }}
-      {{ entity.field_date }}
+      {{ content.field_organizations }}
+      {{ content.field_asst_organizations }}
+      {{ content.field_status }}
+      {{ content.field_date }}
 
     </div>
 

--- a/html/themes/custom/common_design_subtheme/templates/content/external-entity--assessment-document.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/external-entity--assessment-document.html.twig
@@ -4,7 +4,7 @@
  * Default theme implementation to display an external entity.
  *
  * Available variables:
- * - entity: The external entity.
+ * - content: The external entity.
 */
 #}
 {%
@@ -20,13 +20,13 @@
   <div class="cd-teaser__container [ cd-flow ]">
     <div class="cd-teaser__description node__content">
 
-      {{ entity.field_accessibility }}
+      {{ content.field_accessibility }}
 
-      {% if entity.field_accessibility['#items'].getString() == 'Publicly Available' %}
-        {{ entity.field_files }}
-        {{ entity.field_instructions }}
+      {% if content.field_accessibility['#items'].getString() == 'Publicly Available' %}
+        {{ content.field_files }}
+        {{ content.field_instructions }}
       {% else %}
-        {{ entity.field_instructions }}
+        {{ content.field_instructions }}
       {% endif %}
 
     </div>

--- a/html/themes/custom/common_design_subtheme/templates/content/external-entity--full.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/external-entity--full.html.twig
@@ -4,7 +4,7 @@
  * Default theme implementation to display an external entity.
  *
  * Available variables:
- * - entity: The external entity.
+ * - content: The external entity.
 */
 #}
 {%
@@ -19,5 +19,5 @@
 {{ attach_library('common_design/cd-typography') }}
 
 <article{{ attributes.addClass(classes) }}>
-  {{ entity }}
+  {{ content }}
 </article>

--- a/html/themes/custom/common_design_subtheme/templates/content/external-entity--km--teaser.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/external-entity--km--teaser.html.twig
@@ -4,7 +4,7 @@
  * Default theme implementation to display an external entity.
  *
  * Available variables:
- * - entity: The external entity.
+ * - content: The external entity.
 */
 #}
 {%
@@ -19,15 +19,15 @@
 
   <div class="cd-teaser__container [ cd-flow ]">
     <h3 class="cd-teaser__title">
-      {{ entity.title }}
+      {{ content.title }}
     </h3>
 
     <div class="cd-teaser__description node__content">
 
-      {{ entity.field_description }}
-      {{ entity.field_context }}
-      {{ entity.field_life_cycle_steps }}
-      {{ entity.field_population_types }}
+      {{ content.field_description }}
+      {{ content.field_context }}
+      {{ content.field_life_cycle_steps }}
+      {{ content.field_population_types }}
 
     </div>
 

--- a/html/themes/custom/common_design_subtheme/templates/content/external-entity--teaser.html.twig
+++ b/html/themes/custom/common_design_subtheme/templates/content/external-entity--teaser.html.twig
@@ -4,7 +4,7 @@
  * Default theme implementation to display an external entity.
  *
  * Available variables:
- * - entity: The external entity.
+ * - content: The external entity.
 */
 #}
 {%
@@ -19,13 +19,13 @@
 
   <div class="cd-teaser__container [ cd-flow ]">
     <h3 class="cd-teaser__title">
-      {{ entity.title }}
+      {{ content.title }}
     </h3>
 
     <div class="cd-teaser__description node__content">
 
       {# this doesn't seem to work. Title prints regardless #}
-      {{ entity|without('title') }}
+      {{ content|without('title') }}
 
     </div>
 


### PR DESCRIPTION
Refs: AR-286

Matches 'entity' -> 'content' change made in twig template in https://git.drupalcode.org/project/external_entities/-/commit/f5e3405c8565d39fb0862cb8374b3e1a3f99937c