### PR TITLE
feat: add environment indicator and configuration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "drupal/ctools": "^4.0",
         "drupal/custom_widgets": "^2.0",
         "drupal/dream_block_manager": "^1.0",
+        "drupal/environment_indicator": "^4.0",
         "drupal/external_entities": "^2.0-alpha3",
         "drupal/external_media": "^1.0",
         "drupal/facets": "^2.0.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9649df5c597de1c0dbfd5a889670891c",
+    "content-hash": "4a58e6be4e5025d985eabae108178a2c",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2982,6 +2982,54 @@
             "homepage": "https://www.drupal.org/project/dream_block_manager",
             "support": {
                 "source": "https://git.drupalcode.org/project/dream_block_manager"
+            }
+        },
+        {
+            "name": "drupal/environment_indicator",
+            "version": "4.0.14",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/environment_indicator.git",
+                "reference": "4.0.14"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/environment_indicator-4.0.14.zip",
+                "reference": "4.0.14",
+                "shasum": "ff4fe11fcd5fa08b7ba7a451302cf93e5f68449c"
+            },
+            "require": {
+                "drupal/core": "^9.2 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "4.0.14",
+                    "datestamp": "1674120945",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "e0ipso",
+                    "homepage": "https://www.drupal.org/user/550110"
+                },
+                {
+                    "name": "mrfelton",
+                    "homepage": "https://www.drupal.org/user/305669"
+                }
+            ],
+            "description": "Adds a color indicator for the different environments.",
+            "homepage": "https://www.drupal.org/project/environment_indicator",
+            "support": {
+                "source": "https://git.drupalcode.org/project/environment_indicator"
             }
         },
         {

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -18,6 +18,7 @@ module:
   dream_block_manager: 0
   dynamic_page_cache: 0
   editor: 0
+  environment_indicator: 0
   external_entities: 0
   external_media: 0
   facets: 0

--- a/config/environment_indicator.settings.yml
+++ b/config/environment_indicator.settings.yml
@@ -1,0 +1,5 @@
+_core:
+  default_config_hash: Bi0EyyiH6m5wpHRfxlKhqTIhAZayhRQudheDzAcrotU
+toolbar_integration:
+  - toolbar
+favicon: true

--- a/config/environment_indicator.switcher.dev.yml
+++ b/config/environment_indicator.switcher.dev.yml
@@ -1,0 +1,11 @@
+uuid: a3b008b2-0811-41ed-99ce-f6220eb7753f
+langcode: en
+status: true
+dependencies: {  }
+machine: dev
+description: null
+name: Dev
+weight: ''
+url: 'https://dev.assessments-hpc-tools.ahconu.org'
+fg_color: '#000000'
+bg_color: '#34ccc1'

--- a/config/environment_indicator.switcher.local.yml
+++ b/config/environment_indicator.switcher.local.yml
@@ -1,0 +1,11 @@
+uuid: ab2ea9d0-0b63-4729-a117-5eff9d9b901b
+langcode: en
+status: true
+dependencies: {  }
+machine: local
+description: null
+name: Local
+weight: ''
+url: 'https://assessments.test'
+fg_color: '#ffffff'
+bg_color: '#db7b18'

--- a/config/environment_indicator.switcher.prod.yml
+++ b/config/environment_indicator.switcher.prod.yml
@@ -1,0 +1,11 @@
+uuid: 39f3a6a4-5eb5-495d-80b8-516da83daf8a
+langcode: en
+status: true
+dependencies: {  }
+machine: prod
+description: null
+name: Prod
+weight: ''
+url: 'https://assessments.hpc.tools'
+fg_color: '#ffffff'
+bg_color: '#6937ac'

--- a/config/user.role.anonymous.yml
+++ b/config/user.role.anonymous.yml
@@ -1,7 +1,15 @@
 uuid: 92af0954-b861-4177-87fa-6b9ddd91eb8d
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  config:
+    - environment_indicator.switcher.dev
+    - environment_indicator.switcher.local
+  module:
+    - environment_indicator
+    - external_entities
+    - media
+    - system
 _core:
   default_config_hash: pq_mEIu_B4widZN7Ap81iCJSjShFFdcL0jEiCi8VrDk
 id: anonymous
@@ -11,6 +19,8 @@ is_admin: false
 permissions:
   - 'access comments'
   - 'access content'
+  - 'access environment indicator dev'
+  - 'access environment indicator local'
   - 'access site-wide contact form'
   - 'search content'
   - 'view assessment external entity'

--- a/config/user.role.authenticated.yml
+++ b/config/user.role.authenticated.yml
@@ -1,7 +1,17 @@
 uuid: a0292b0a-0d07-4841-97c6-97b602554a81
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  config:
+    - environment_indicator.switcher.dev
+    - environment_indicator.switcher.local
+    - filter.format.basic_html
+  module:
+    - environment_indicator
+    - external_entities
+    - filter
+    - media
+    - system
 _core:
   default_config_hash: btW6TFHajhy7Eo6YUvdFiPh4TcPggo8GBXYctjV6zag
 id: authenticated
@@ -11,6 +21,8 @@ is_admin: false
 permissions:
   - 'access comments'
   - 'access content'
+  - 'access environment indicator dev'
+  - 'access environment indicator local'
   - 'access site-wide contact form'
   - 'post comments'
   - 'search content'


### PR DESCRIPTION
Refs: OPS-8939

Adds Environment indicator for local and dev environments - there's an indicator configured for prod too, but no permissions for any roles to see it.

Based on the changes in https://github.com/UN-OCHA/common-design-site/pull/252 - but using the color for the 'feature' environment for 'local'. Not sure if we want a dedicated color for local so we can have more consistency.