### PR TITLE
fix: testing config for preserve-paths

### DIFF
--- a/PATCHES/preserve-paths-workaround.patch
+++ b/PATCHES/preserve-paths-workaround.patch
@@ -1,5 +1,5 @@
 diff --git a/src/PluginWrapper.php b/src/PluginWrapper.php
-index c2a2cbc..5b19909 100644
+index c2a2cbc..4d520a7 100644
 --- a/src/PluginWrapper.php
 +++ b/src/PluginWrapper.php
 @@ -133,7 +133,7 @@ protected function getInstallPathsFromPackages(array $packages)
@@ -11,3 +11,13 @@ index c2a2cbc..5b19909 100644
          }
  
          return $this->absolutePaths($paths);
+@@ -187,6 +187,9 @@ protected function absolutePaths($paths)
+     {
+         $return = array();
+         foreach ($paths as $path) {
++            if (empty($path)) {
++                continue;
++            }
+             if (!$this->filesystem->isAbsolutePath($path)) {
+                 $path = getcwd().'/'.$path;
+             }

--- a/PATCHES/preserve-paths-workaround.patch
+++ b/PATCHES/preserve-paths-workaround.patch
@@ -1,0 +1,13 @@
+diff --git a/src/PluginWrapper.php b/src/PluginWrapper.php
+index c2a2cbc..5b19909 100644
+--- a/src/PluginWrapper.php
++++ b/src/PluginWrapper.php
+@@ -133,7 +133,7 @@ protected function getInstallPathsFromPackages(array $packages)
+ 
+         $paths = array();
+         foreach ($packages as $package) {
+-            $paths[] = $installationManager->getInstallPath($package);
++            $paths[] = (string) $installationManager->getInstallPath($package);
+         }
+ 
+         return $this->absolutePaths($paths);

--- a/composer.json
+++ b/composer.json
@@ -143,7 +143,8 @@
         },
         "preserve-paths": [
             "html/modules/custom",
-            "html/themes/custom"
+            "html/themes/custom",
+            "html/sites/default"
         ],
         "patches-file": "composer.patches.json",
         "composer-exit-on-patch-failure": true

--- a/composer.json
+++ b/composer.json
@@ -143,8 +143,7 @@
         },
         "preserve-paths": [
             "html/modules/custom",
-            "html/themes/custom",
-            "html/sites/default"
+            "html/themes/custom"
         ],
         "patches-file": "composer.patches.json",
         "composer-exit-on-patch-failure": true

--- a/composer.patches.json
+++ b/composer.patches.json
@@ -1,5 +1,8 @@
 {
   "patches": {
+    "drupal-composer/preserve-paths": {
+      "Workaround for empty paths": "PATCHES/preserve-paths-workaround.patch"
+    },
     "drupal/core": {
       "https://www.drupal.org/project/drupal/issues/2859042#comment-12366507": "https://www.drupal.org/files/issues/entity-original_revision-2926483-17.patch",
       "https://www.drupal.org/project/drupal/issues/3143617": "https://www.drupal.org/files/issues/2020-07-07/3143617-28_0.patch"


### PR DESCRIPTION
Refs: updates

All the periodic updates that have drupal-composer/preserve-paths package fail on:
```
Error: Composer\Util\Filesystem::isAbsolutePath(): Argument #1 ($path) must be of type string, null given, called in /home/runner/work/gms-site/gms-site/vendor/drupal-composer/preserve-paths/src/PluginWrapper.php on line 190

In Filesystem.php line 521:
                                                                               
  [TypeError]                                                                  
  Composer\Util\Filesystem::isAbsolutePath(): Argument #1 ($path) must be of   
  type string, null given, called in /home/runner/work/gms-site/gms-site/vend  
  or/drupal-composer/preserve-paths/src/PluginWrapper.php on line 190          
```
This is an attempt to see if altering the configuration helps. (Noting too that IASC, numbers and RWR don't use the preserve-paths package).