### PR TITLE
fix: pin composer version till preserve-paths is updated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_script:
   # Composer.
   - sed -i '1i export PATH="$HOME/.composer/vendor/bin:$PATH"' $HOME/.bashrc
   - source $HOME/.bashrc
-  - composer self-update --2
+  - composer self-update 2.5.5
 
   # Ensure the PHP environment is ready.
   - phpenv rehash


### PR DESCRIPTION
Refs: updates

Thinking this is the solution I was looking for in https://github.com/UN-OCHA/assessmentregistry8-site/pull/510