### PR TITLE
fix: Make nginx do a dns lookup on each request by making the proxy h…

### DIFF
--- a/docker/etc/nginx/apps/drupal/drupal.conf
+++ b/docker/etc/nginx/apps/drupal/drupal.conf
@@ -44,9 +44,10 @@ location / {
     ## Also, do not attempt to buffer, just throw the data out right away and close the docstore connection
     ## when done.
     location ^~ /attachments/ {
+      set $docstore_host "docstore.ahconu.org.internal";
       # Rewrite the url to what the dcostore wants.
       rewrite /attachments/(.+)$ /files/$1 break;
-      proxy_pass http://docstore.ahconu.org.internal;
+      proxy_pass http://$docstore_host;
       # Override connection and buffer vars.
       proxy_set_header Connection '';
       proxy_buffering off;

--- a/docker/etc/nginx/custom/docstore.conf
+++ b/docker/etc/nginx/custom/docstore.conf
@@ -1,3 +1,4 @@
 location ~ ^/attachments/([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/([^/]+)(\.[0-9a-zA-Z]+)$" {
-  proxy_pass http://docstore.ahconu.org.internal/files/$1$2$3$5;
+  set $docstore_host "docstore.ahconu.org.internal";
+  proxy_pass http://$docstore_host/files/$1$2$3$5;
 }


### PR DESCRIPTION
…ost a variable.

That means if the IPs for the load balancer change, Docstore requests will keep working instead of erroring out until a container restart.

Refs: OPS-9534